### PR TITLE
update setup: remove filebrowser, plex and update docs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -231,36 +231,6 @@ http://localhost:8083/calibreweb/kobo/{token}/v1/library/sync
 
 Go the api_endpoint in browser. If this is empty, consider pressing "Force full kobo sync" in the user options in calibre-web
 
-### Filebrowser
-
-`- /home/${USER}/Applications/Filebrowser:/srv`
-
-Mounts a single folder called Filebrowser to /srv. This folder must be empty.
-
-Other folders are mounted as such: /srv/Pictures
-so they are accessible in the container as /Pictures
-
-This will create Pictures/ under Applications. Pictures/ will be empty
-
-filebrowser.db must exist before mounting, else mounts a directory
-`touch filebrowser.db`
-
-same with settings.json
-
-```
-❯ cat settings.json
-{
-  "port": 80,
-  "baseURL": "",
-  "address": "",
-  "log": "stdout",
-  "database": "/database/filebrowser.db",
-  "root": "/srv"
-}
-```
-
-admin/admin on initial login :8090
-
 ### Openbooks
 
 documentation: https://evan-buss.github.io/openbooks/setup/docker/

--- a/.github/README.md
+++ b/.github/README.md
@@ -83,6 +83,13 @@ Optional Stacks:
           └── tv
 ```
 
+```sh
+mkdir -p appdata/{bazarr,calibre,calibre-web,filebrowser,freshrss,jackett,jellyfin,jellyseerr,lidarr,linkwarden,openbooks,organizr,overseerr,plex,prowlarr,radarr,slskd,sonarr,soularr,soulseek,traefik,transmission} \
+data/media/{books,books_not_in_library,filebrowser,movies,music,tv} \
+data/soulseek/{downloads,incomplete} \
+data/torrents/{incomplete,movies,tv}
+```
+
 ## Deploying the stack
 
 This section covers deployment options for your home media server stack. You can choose to deploy using Portainer, Docker Compose with Docker Desktop, or Podman. Each method has its own advantages, but for simplicity and ease of use, I recommend using Portainer.

--- a/.github/README.md
+++ b/.github/README.md
@@ -171,7 +171,7 @@ http://prowlarr:9696
 http://radarr:7878
 ```
 
-### Sonarr, radarr, lidarr
+### Sonarr, radarr
 
 These services require you to setup an indexer (prowlarr) and a download client (transmission)
 
@@ -253,7 +253,7 @@ https://github.com/causefx/Organizr
 default username and password:
 slskd
 
-soularr api_keys
+soularr api_keys for use in `Soularr` setup below
 
 change passwords:
 ```
@@ -266,6 +266,16 @@ mysecurepassword
 example config in `slskd/slskd.yml`
 
 `appdata/slskd/slskd.yml`
+
+### Lidarr + Soularr
+
+Lidarr only requires a root folder to be setup. Soularr handles starting downloads with Slskd
+
+https://soularr.net
+
+`appdata/soularr/config.ini`
+
+setup API Key for Soularr and Lidarr
 
 ## Credits
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -253,7 +253,19 @@ https://github.com/causefx/Organizr
 default username and password:
 slskd
 
+soularr api_keys
+
+change passwords:
+```
+localusername
+localpassword
+username
+mysecurepassword
+```
+
 example config in `slskd/slskd.yml`
+
+`appdata/slskd/slskd.yml`
 
 ## Credits
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -156,13 +156,13 @@ manually install
 
 https://github.com/johman10/flood-for-transmission
 
-1. cd appdata/transmission
-2. curl
-3. unzip
+1. cd `appdata/transmission`
+2. curl / download
+3. extract so that `appdata/transmission/flood-for-transmission`
 
 ### Prowlarr
 
-https://docs.prowler.com/projects/prowler-open-source/en/latest/
+https://prowlarr.com/#downloads-v3-docker
 
 instead of localhost, use their service names:
 

--- a/docker-compose-novpn.yml
+++ b/docker-compose-novpn.yml
@@ -43,24 +43,6 @@ services:
       - '${HMS_CALIBRE_WEB_PORT:-8083}:8083'
     restart: unless-stopped
 
-  filebrowser:
-    image: filebrowser/filebrowser:v2-s6
-    container_name: filebrowser
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - ${HMS_ROOT_APPDATA}/filebrowser/filebrowser.db:/database/filebrowser.db
-      - ${HMS_ROOT_APPDATA}/filebrowser/settings.json:/config/settings.json
-      # Shared folders root is /srv
-      # After updating folders run: rm filebrowser.db ; touch filebrowser.db ; rm -rf ~/Filebrowser/*
-      - ${HMS_ROOT_DATA}/media/filebrowser:/srv
-    environment:
-      - FB_BASEURL=/filebrowser
-    env_file:
-      - stack.env
-    ports:
-      - '${HMS_FILEBROWSER_PORT:-8090}:80'
-    restart: unless-stopped
-
   freshrss:
     image: linuxserver/freshrss:1.27.0
     container_name: freshrss

--- a/docker-compose-novpn.yml
+++ b/docker-compose-novpn.yml
@@ -2,7 +2,7 @@ name: "home-media-server-novpn"
 
 services:
   bazarr:
-    image: hotio/bazarr:release-1.5.1
+    image: linuxserver/bazarr:1.5.2
     container_name: bazarr
     volumes:
       - /etc/localtime:/etc/localtime:ro

--- a/docker-compose-novpn.yml
+++ b/docker-compose-novpn.yml
@@ -172,19 +172,6 @@ services:
       - '${HMS_OVERSEERR_PORT:-5055}:5055'
     restart: unless-stopped
 
-  plex:
-    image: linuxserver/plex:1.41.9
-    container_name: plex
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - ${HMS_ROOT_APPDATA}/plex:/config
-      - ${HMS_ROOT_DATA}/media:/data/media
-    env_file:
-      - stack.env
-    ports:
-      - '${HMS_PLEX_PORT:-32400}:32400'
-    restart: unless-stopped
-
   postgres:
     image: postgres:16-alpine
     container_name: "linkwarden-postgres"

--- a/home-media-server-novpn.env
+++ b/home-media-server-novpn.env
@@ -1,5 +1,5 @@
-HMS_ROOT_APPDATA=/media/${USER}/Data/appdata
-HMS_ROOT_DATA=/media/${USER}/Data/data
+HMS_ROOT_APPDATA=/mnt/Data/appdata
+HMS_ROOT_DATA=/mnt/Data/data
 OPENBOOKS_DISPLAY_NAME=coolguy69
 PGID=1000
 PUID=1000

--- a/secrets-example.env
+++ b/secrets-example.env
@@ -1,5 +1,4 @@
 JELLYFIN_PUBLISHED_SERVER_URL=http://
 NEXTAUTH_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-PLEX_CLAIM=claim-xxxxxxxxxxxxxxxxx
 POSTGRES_PASSWORD=password
 USER=user


### PR DESCRIPTION
This pull request updates the home media server setup documentation and configuration files to streamline service management, clarify installation instructions, and remove unused components. The most significant changes are the removal of the `filebrowser` and `plex` services from the Docker Compose stack, improvements to the documentation for setting up directories and several services, and updates to environment variable paths.

**Service Removal and Configuration Updates:**

* Removed the `filebrowser` and `plex` services from the `docker-compose-novpn.yml` stack to simplify the deployment and eliminate unused components. [[1]](diffhunk://#diff-b1ea428aab01cc19034c87734f81f4e056adf1cfa218f1a4fc6476111a97a755L46-L63) [[2]](diffhunk://#diff-b1ea428aab01cc19034c87734f81f4e056adf1cfa218f1a4fc6476111a97a755L175-L187)
* Updated the Bazarr image to use `linuxserver/bazarr:1.5.2` instead of `hotio/bazarr:release-1.5.1` in `docker-compose-novpn.yml` for improved compatibility and support.
* Changed environment variable paths in `home-media-server-novpn.env` to use `/mnt/Data` instead of `/media/${USER}/Data` for consistency and reliability.

**Documentation Improvements:**

* Added a shell command example to quickly create necessary directories for app data and media storage in `.github/README.md`.
* Clarified manual installation instructions for Transmission and updated the Prowlarr documentation link for easier setup.
* Improved documentation for Lidarr and Soularr integration, including configuration file locations and API key setup.
* Removed outdated and redundant documentation for Filebrowser, reflecting its removal from the stack.

**Other Minor Updates:**

* Adjusted documentation to remove Lidarr from the Sonarr/Radarr section, further clarifying setup steps.
* Removed the `PLEX_CLAIM` secret from `secrets-example.env` since Plex is no longer included in the stack.